### PR TITLE
Pyatom disappeared

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,44 @@
+name: Run tests
+
+on:
+  push:
+  schedule:
+    - cron: "0 10 * * 0"
+
+
+jobs:
+  tests:
+    name: Run the tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Configure pip caching
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127   --statistics  
+      - name: Test with pytest
+        run: |
+          pip install pytest
+          pytest -v

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+![Run tests](https://github.com/norm/flourish/workflows/Run%20tests/badge.svg)
+
 Flourish
 ========
 

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -5,6 +5,7 @@ from importlib.machinery import SourceFileLoader
 from operator import attrgetter, itemgetter
 import os
 from shutil import copyfile, rmtree
+import sys
 import warnings
 
 from jinja2 import Environment, FileSystemLoader
@@ -19,6 +20,8 @@ from .source import (
 )
 from .url import URL
 from .version import __version__    # noqa: F401
+
+sys.dont_write_bytecode = True
 
 
 class Flourish(object):

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -1,7 +1,7 @@
 # encoding: utf8
 
 from datetime import datetime
-from imp import load_source
+from importlib.machinery import SourceFileLoader
 from operator import attrgetter, itemgetter
 import os
 from shutil import copyfile, rmtree
@@ -81,7 +81,9 @@ class Flourish(object):
         if '_source_files' not in kwargs:
             self._add_sources()
 
-        generate = load_source('generate', '%s/generate.py' % self.source_dir)
+        generate = SourceFileLoader(
+                'generate', '%s/generate.py' % self.source_dir
+            ).load_module()
         try:
             self.set_global_context(getattr(generate, 'GLOBAL_CONTEXT'))
         except AttributeError:

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -105,7 +105,7 @@ class Flourish(object):
             for url in generate.URLS:
                 has_urls = True
                 self.add_url(*url)
-        except:
+        except NameError:
             # other URLs are optional
             pass
 

--- a/flourish/examples.py
+++ b/flourish/examples.py
@@ -113,7 +113,7 @@ example_files = {
         ## Changing the site-wide configuration
 
         There is a file `_site.toml` in the `source` directory. It is not the source
-        for any specific page, but rather it is site-wide configuration. 
+        for any specific page, but rather it is site-wide configuration.
 
         Open it in your text editor and change the text "Your Name Goes Here" to
         contain your name, save the file, reload this webpage and scroll to the
@@ -129,20 +129,20 @@ example_files = {
         published = 2016-06-29T10:00:00Z
         ---
 
-        Welcome to your new blog, powered by Flourish. This example content will 
+        Welcome to your new blog, powered by Flourish. This example content will
         walk you through the basics of getting started using Flourish.
 
         Try clicking around the site. See how the title at the top of the page always
         takes you to the homepage and that there are three posts linked from there;
         that "2016" takes you to a similar list of pages, but the "06" and "07" links
-        show less links? These links are all programmatically generated from the 
+        show less links? These links are all programmatically generated from the
         site's source.
 
         The homepage links to all pages, the "2016" page links to all pages published
         in the year 2016, and "06" and "07" link to pages published in June and July
         of that year.
 
-        Having familiarised yourself with the site as it is now, let's start 
+        Having familiarised yourself with the site as it is now, let's start
         [editing it!](/editing-the-site)
     """),   # noqa: E501
 

--- a/flourish/generators.py
+++ b/flourish/generators.py
@@ -199,7 +199,7 @@ class AtomGenerator(BaseGenerator):
 
     def render_output(self):
         feed = FeedGenerator()
-        feed.author({'name':self.flourish.site_config['author']})
+        feed.author({'name': self.flourish.site_config['author']})
         feed.title(self.flourish.site_config['title'])
         # feed.link(self.flourish.site_config['base_url'])
         feed.id('%s%s' % (
@@ -223,9 +223,9 @@ class AtomGenerator(BaseGenerator):
             entry.content(content=_object.body, type='html')
 
             if 'author' in _object:
-                entry.author({'name':_object.author})
+                entry.author({'name': _object.author})
             else:
-                entry.author({'name':self.flourish.site_config['author']})
+                entry.author({'name': self.flourish.site_config['author']})
 
             if 'updated' in _object:
                 entry.updated(_object.updated)

--- a/flourish/paginator.py
+++ b/flourish/paginator.py
@@ -1,4 +1,4 @@
-from collections import Sequence
+from collections.abc import Sequence
 from math import ceil
 
 

--- a/flourish/source.py
+++ b/flourish/source.py
@@ -153,7 +153,7 @@ class MarkdownSourceFile(SourceFile):
                 _, _frontmatter, _body = FM_SPLIT.split(content, 2)
                 config = toml.loads(_frontmatter)
                 config['body_markdown'] = _body
-            except:
+            except ValueError:
                 raise RuntimeError(
                     '"%s" has no end marker for the frontmatter' % filename
                 )

--- a/flourish/source.py
+++ b/flourish/source.py
@@ -1,5 +1,5 @@
 import codecs
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 import json
 import os
@@ -177,5 +177,7 @@ class JsonSourceFile(SourceFile):
 
         for _key, _value in _config.items():
             if type(_value) == str and self.ISO8601.match(_value):
-                _config[_key] = datetime.strptime(_value, "%Y-%m-%dT%H:%M:%SZ")
+                _config[_key] = datetime.strptime(
+                        _value, "%Y-%m-%dT%H:%M:%SZ"
+                    ).replace(tzinfo=timezone.utc)
         return _config

--- a/flourish/url.py
+++ b/flourish/url.py
@@ -11,14 +11,14 @@ class URL(object):
     @property
     def arguments(self):
         _arguments = []
-        for _segment in re.split('(#\w+)', self.path):
+        for _segment in re.split(r'(#\w+)', self.path):
             if _segment.startswith('#'):
                 _arguments.append(_segment[1:])
         return _arguments
 
     def resolve(self, **kwargs):
         _resolved = ''
-        for _segment in re.split('(#\w+)', self.path):
+        for _segment in re.split(r'(#\w+)', self.path):
             if _segment.startswith('#'):
                 key = _segment[1:]
                 if key in kwargs:

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
         'Flask',
         'Jinja2',
         'markdown2',
-        'pyatom',
-        'toml.py',
+        'feedgen',
+        'toml',
         'watchdog',
     ],
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite('tests.compare_directories')

--- a/tests/output/index.atom
+++ b/tests/output/index.atom
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/index.atom</id>
-  <updated>2016-06-06T10:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-06T10:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Part Three</title>
+  <link href="http://withaflourish.net/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/series/part-three</id>
-    <updated>2016-06-06T10:00:00Z</updated>
-    <published>2016-06-06T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-three" />
+    <title>Part Three</title>
+    <updated>2016-06-06T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -22,38 +20,38 @@
 
 &lt;p&gt;The embedded Markdown gets overridden.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-three" rel="alternate"/>
+    <published>2016-06-06T10:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Thing—the First</title>
+  <entry>
     <id>http://withaflourish.net/thing-one</id>
-    <updated>2016-06-04T14:00:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-one" />
+    <title>Thing—the First</title>
+    <updated>2016-06-04T14:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;Thing the First&lt;/h1&gt;
 &lt;p&gt;This is raw HTML.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-one" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Second Thing</title>
+  <entry>
     <id>http://withaflourish.net/thing-two</id>
-    <updated>2016-06-04T12:30:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-two" />
+    <title>Second Thing</title>
+    <updated>2016-06-04T12:30:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Body read from Markdown attachment‽&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-two" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Part Two</title>
+  <entry>
     <id>http://withaflourish.net/series/part-two</id>
-    <updated>2016-06-04T12:00:00Z</updated>
-    <published>2016-06-04T12:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-two" />
+    <title>Part Two</title>
+    <updated>2016-06-04T12:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -61,13 +59,13 @@
 
 &lt;p&gt;I come from a Markdown file.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-two" rel="alternate"/>
+    <published>2016-06-04T12:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Part One</title>
+  <entry>
     <id>http://withaflourish.net/series/part-one</id>
-    <updated>2016-06-04T11:00:00Z</updated>
-    <published>2016-06-04T11:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-one" />
+    <title>Part One</title>
+    <updated>2016-06-04T11:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -75,25 +73,25 @@
 
 &lt;p&gt;I come from Markdown.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-one" rel="alternate"/>
+    <published>2016-06-04T11:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">A Series in Three Parts</title>
+  <entry>
     <id>http://withaflourish.net/series/</id>
-    <updated>2016-06-04T10:00:00Z</updated>
-    <published>2016-06-04T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/" />
+    <title>A Series in Three Parts</title>
+    <updated>2016-06-04T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;A Series in Three Parts&lt;/h1&gt;
 </content>
+    <link href="http://withaflourish.net/series/" rel="alternate"/>
+    <published>2016-06-04T10:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Plain Markdown Page</title>
+  <entry>
     <id>http://withaflourish.net/markdown-page</id>
-    <updated>2016-02-29T10:30:00Z</updated>
-    <published>2016-02-29T10:30:00Z</published>
-    <link href="http://withaflourish.net/markdown-page" />
+    <title>Plain Markdown Page</title>
+    <updated>2016-02-29T10:30:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -101,16 +99,18 @@
 
 &lt;p&gt;I was generated from Markdown alone, no TOML.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/markdown-page" rel="alternate"/>
+    <published>2016-02-29T10:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/index.atom">
-    <title type="text">Basic Page</title>
+  <entry>
     <id>http://withaflourish.net/basic-page</id>
-    <updated>2015-12-25T10:00:00Z</updated>
-    <published>2015-12-25T10:00:00Z</published>
-    <link href="http://withaflourish.net/basic-page" />
+    <title>Basic Page</title>
+    <updated>2015-12-25T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Hello “world”.&lt;/p&gt;</content>
+    <link href="http://withaflourish.net/basic-page" rel="alternate"/>
+    <published>2015-12-25T10:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/basic-page/index.atom
+++ b/tests/output/tags/basic-page/index.atom
@@ -1,23 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/basic-page/index.atom</id>
-  <updated>2015-12-25T10:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/basic-page/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2015-12-25T10:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/basic-page/index.atom">
-    <title type="text">Basic Page</title>
+  <link href="http://withaflourish.net/tags/basic-page/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/basic-page</id>
-    <updated>2015-12-25T10:00:00Z</updated>
-    <published>2015-12-25T10:00:00Z</published>
-    <link href="http://withaflourish.net/basic-page" />
+    <title>Basic Page</title>
+    <updated>2015-12-25T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Hello “world”.&lt;/p&gt;</content>
+    <link href="http://withaflourish.net/basic-page" rel="alternate"/>
+    <published>2015-12-25T10:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/basically/index.atom
+++ b/tests/output/tags/basically/index.atom
@@ -1,37 +1,37 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/basically/index.atom</id>
-  <updated>2016-06-04T14:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/basically/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T14:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/basically/index.atom">
-    <title type="text">Thing—the First</title>
+  <link href="http://withaflourish.net/tags/basically/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/thing-one</id>
-    <updated>2016-06-04T14:00:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-one" />
+    <title>Thing—the First</title>
+    <updated>2016-06-04T14:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;Thing the First&lt;/h1&gt;
 &lt;p&gt;This is raw HTML.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-one" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/basically/index.atom">
-    <title type="text">Second Thing</title>
+  <entry>
     <id>http://withaflourish.net/thing-two</id>
-    <updated>2016-06-04T12:30:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-two" />
+    <title>Second Thing</title>
+    <updated>2016-06-04T12:30:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Body read from Markdown attachment‽&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-two" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/first/index.atom
+++ b/tests/output/tags/first/index.atom
@@ -1,25 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/first/index.atom</id>
-  <updated>2016-06-04T14:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/first/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T14:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/first/index.atom">
-    <title type="text">Thing—the First</title>
+  <link href="http://withaflourish.net/tags/first/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/thing-one</id>
-    <updated>2016-06-04T14:00:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-one" />
+    <title>Thing—the First</title>
+    <updated>2016-06-04T14:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;Thing the First&lt;/h1&gt;
 &lt;p&gt;This is raw HTML.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-one" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/index/index.atom
+++ b/tests/output/tags/index/index.atom
@@ -1,24 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/index/index.atom</id>
-  <updated>2016-06-04T10:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/index/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T10:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/index/index.atom">
-    <title type="text">A Series in Three Parts</title>
+  <link href="http://withaflourish.net/tags/index/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/series/</id>
-    <updated>2016-06-04T10:00:00Z</updated>
-    <published>2016-06-04T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/" />
+    <title>A Series in Three Parts</title>
+    <updated>2016-06-04T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;A Series in Three Parts&lt;/h1&gt;
 </content>
+    <link href="http://withaflourish.net/series/" rel="alternate"/>
+    <published>2016-06-04T10:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/one/index.atom
+++ b/tests/output/tags/one/index.atom
@@ -1,33 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/one/index.atom</id>
-  <updated>2016-06-04T14:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/one/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T14:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/one/index.atom">
-    <title type="text">Thing—the First</title>
+  <link href="http://withaflourish.net/tags/one/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/thing-one</id>
-    <updated>2016-06-04T14:00:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-one" />
+    <title>Thing—the First</title>
+    <updated>2016-06-04T14:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;Thing the First&lt;/h1&gt;
 &lt;p&gt;This is raw HTML.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-one" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/one/index.atom">
-    <title type="text">Part One</title>
+  <entry>
     <id>http://withaflourish.net/series/part-one</id>
-    <updated>2016-06-04T11:00:00Z</updated>
-    <published>2016-06-04T11:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-one" />
+    <title>Part One</title>
+    <updated>2016-06-04T11:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -35,5 +33,7 @@
 
 &lt;p&gt;I come from Markdown.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-one" rel="alternate"/>
+    <published>2016-06-04T11:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/second/index.atom
+++ b/tests/output/tags/second/index.atom
@@ -1,24 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/second/index.atom</id>
-  <updated>2016-06-04T12:30:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/second/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T12:30:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/second/index.atom">
-    <title type="text">Second Thing</title>
+  <link href="http://withaflourish.net/tags/second/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/thing-two</id>
-    <updated>2016-06-04T12:30:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-two" />
+    <title>Second Thing</title>
+    <updated>2016-06-04T12:30:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Body read from Markdown attachment‽&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-two" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/series/index.atom
+++ b/tests/output/tags/series/index.atom
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/series/index.atom</id>
-  <updated>2016-06-06T10:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/series/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-06T10:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/series/index.atom">
-    <title type="text">Part Three</title>
+  <link href="http://withaflourish.net/tags/series/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/series/part-three</id>
-    <updated>2016-06-06T10:00:00Z</updated>
-    <published>2016-06-06T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-three" />
+    <title>Part Three</title>
+    <updated>2016-06-06T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -22,13 +20,13 @@
 
 &lt;p&gt;The embedded Markdown gets overridden.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-three" rel="alternate"/>
+    <published>2016-06-06T10:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/series/index.atom">
-    <title type="text">Part Two</title>
+  <entry>
     <id>http://withaflourish.net/series/part-two</id>
-    <updated>2016-06-04T12:00:00Z</updated>
-    <published>2016-06-04T12:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-two" />
+    <title>Part Two</title>
+    <updated>2016-06-04T12:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -36,13 +34,13 @@
 
 &lt;p&gt;I come from a Markdown file.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-two" rel="alternate"/>
+    <published>2016-06-04T12:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/series/index.atom">
-    <title type="text">Part One</title>
+  <entry>
     <id>http://withaflourish.net/series/part-one</id>
-    <updated>2016-06-04T11:00:00Z</updated>
-    <published>2016-06-04T11:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-one" />
+    <title>Part One</title>
+    <updated>2016-06-04T11:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -50,17 +48,19 @@
 
 &lt;p&gt;I come from Markdown.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-one" rel="alternate"/>
+    <published>2016-06-04T11:00:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/series/index.atom">
-    <title type="text">A Series in Three Parts</title>
+  <entry>
     <id>http://withaflourish.net/series/</id>
-    <updated>2016-06-04T10:00:00Z</updated>
-    <published>2016-06-04T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/" />
+    <title>A Series in Three Parts</title>
+    <updated>2016-06-04T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;A Series in Three Parts&lt;/h1&gt;
 </content>
+    <link href="http://withaflourish.net/series/" rel="alternate"/>
+    <published>2016-06-04T10:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/three/index.atom
+++ b/tests/output/tags/three/index.atom
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/three/index.atom</id>
-  <updated>2016-06-06T10:00:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/three/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-06T10:00:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/three/index.atom">
-    <title type="text">Part Three</title>
+  <link href="http://withaflourish.net/tags/three/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/series/part-three</id>
-    <updated>2016-06-06T10:00:00Z</updated>
-    <published>2016-06-06T10:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-three" />
+    <title>Part Three</title>
+    <updated>2016-06-06T10:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -22,5 +20,7 @@
 
 &lt;p&gt;The embedded Markdown gets overridden.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-three" rel="alternate"/>
+    <published>2016-06-06T10:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/output/tags/two/index.atom
+++ b/tests/output/tags/two/index.atom
@@ -1,32 +1,30 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-  <title type="text">Flourish Blog</title>
   <id>http://withaflourish.net/tags/two/index.atom</id>
-  <updated>2016-06-04T12:30:00Z</updated>
-  <link href="http://withaflourish.net" />
-  <link href="http://withaflourish.net/tags/two/index.atom" rel="self" />
+  <title>Flourish Blog</title>
+  <updated>2016-06-04T12:30:00+00:00</updated>
   <author>
     <name>Wendy Testaburger</name>
   </author>
-  <generator>PyAtom</generator>
-  <entry xml:base="http://withaflourish.net/tags/two/index.atom">
-    <title type="text">Second Thing</title>
+  <link href="http://withaflourish.net/tags/two/index.atom" rel="self"/>
+  <link href="http://withaflourish.net" rel="alternate"/>
+  <generator uri="https://lkiesow.github.io/python-feedgen" version="0.9.0">python-feedgen</generator>
+  <entry>
     <id>http://withaflourish.net/thing-two</id>
-    <updated>2016-06-04T12:30:00Z</updated>
-    <published>2016-06-04T12:30:00Z</published>
-    <link href="http://withaflourish.net/thing-two" />
+    <title>Second Thing</title>
+    <updated>2016-06-04T12:30:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Body read from Markdown attachment‽&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/thing-two" rel="alternate"/>
+    <published>2016-06-04T12:30:00+00:00</published>
   </entry>
-  <entry xml:base="http://withaflourish.net/tags/two/index.atom">
-    <title type="text">Part Two</title>
+  <entry>
     <id>http://withaflourish.net/series/part-two</id>
-    <updated>2016-06-04T12:00:00Z</updated>
-    <published>2016-06-04T12:00:00Z</published>
-    <link href="http://withaflourish.net/series/part-two" />
+    <title>Part Two</title>
+    <updated>2016-06-04T12:00:00+00:00</updated>
     <author>
       <name>Wendy Testaburger</name>
     </author>
@@ -34,5 +32,7 @@
 
 &lt;p&gt;I come from a Markdown file.&lt;/p&gt;
 </content>
+    <link href="http://withaflourish.net/series/part-two" rel="alternate"/>
+    <published>2016-06-04T12:00:00+00:00</published>
   </entry>
 </feed>

--- a/tests/source/generate.py
+++ b/tests/source/generate.py
@@ -34,6 +34,7 @@ def global_context(self):
         'copyright_year_range': publication_range(self.flourish),
     }
 
+
 GLOBAL_CONTEXT = global_context
 
 SOURCE_URL = (

--- a/tests/test_flourish_object.py
+++ b/tests/test_flourish_object.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -171,7 +171,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(published=on)
         assert type(sources) == Flourish
         assert len(sources) == 2
@@ -181,7 +181,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_exclude_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(published=on)
         assert type(sources) == Flourish
         assert len(sources) == 6
@@ -207,7 +207,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_less_than(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(published__lt=on)
         assert type(sources) == Flourish
         assert len(sources) == 5
@@ -220,7 +220,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_exclude_less_than(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(published__lt=on)
         assert type(sources) == Flourish
         assert len(sources) == 3
@@ -231,7 +231,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_less_than_or_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(published__lte=on)
         assert type(sources) == Flourish
         assert len(sources) == 7
@@ -246,7 +246,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_exclude_less_than_or_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(published__lte=on)
         assert type(sources) == Flourish
         assert len(sources) == 1
@@ -255,7 +255,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_greater_than(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(published__gt=on)
         assert type(sources) == Flourish
         assert len(sources) == 1
@@ -264,7 +264,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_exclude_greater_than(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(published__gt=on)
         assert type(sources) == Flourish
         assert len(sources) == 7
@@ -279,7 +279,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_greater_than_or_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(published__gte=on)
         assert type(sources) == Flourish
         assert len(sources) == 3
@@ -290,7 +290,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_exclude_greater_than_or_equal_to(self):
-        on = datetime(2016, 6, 4, 12, 30, 0)
+        on = datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(published__gte=on)
         assert type(sources) == Flourish
         assert len(sources) == 5
@@ -608,7 +608,7 @@ class TestFlourish:
         # only two sources have the tag 'two'; three of the six sources were
         # published before 12:15, three published after 12:15; filtering
         # against both of these should only find one post in each subgroup
-        on = datetime(2016, 6, 4, 12, 15, 0)
+        on = datetime(2016, 6, 4, 12, 15, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.filter(
             tag__contains='two', published__gt=on)
         assert type(sources) == Flourish
@@ -644,7 +644,7 @@ class TestFlourish:
     def test_exclude_multiple_arguments(self):
         # only two sources are not of the type 'post'; one was published
         # in 2015, one in 2016
-        on = datetime(2016, 1, 1, 0, 0, 0)
+        on = datetime(2016, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         sources = self.flourish.sources.exclude(type='post', published__gte=on)
         assert type(sources) == Flourish
         assert len(sources) == 1
@@ -678,7 +678,7 @@ class TestFlourish:
             ] == [source.slug for source in sources]
 
     def test_filter_then_exclude(self):
-        on = datetime(2016, 6, 4, 12, 00, 00)
+        on = datetime(2016, 6, 4, 12, 00, 00, tzinfo=timezone.utc)
         posts = self.flourish.sources.filter(type='post')
         sources = posts.exclude(published__gte=on)
         assert type(sources) == Flourish
@@ -697,7 +697,7 @@ class TestFlourish:
             ] == [source.slug for source in posts]
 
     def test_filter_and_exclude_doesnt_affect_parent(self):
-        on = datetime(2016, 6, 4, 12, 15, 0)
+        on = datetime(2016, 6, 4, 12, 15, 0, tzinfo=timezone.utc)
         filtered = self.flourish.sources.filter(
             tag__contains='two', published__gt=on)
         assert type(filtered) == Flourish
@@ -822,7 +822,7 @@ class TestFlourish:
                 ] == [source.slug for source in sources]
 
         with pytest.warns(None) as warnings:
-            on = datetime(2016, 6, 4, 12, 15, 0)
+            on = datetime(2016, 6, 4, 12, 15, 0, tzinfo=timezone.utc)
             sources = self.flourish.sources.exclude(published__lt=on)
             assert len(sources) == 3
             sources = sources.order_by('type', '-published')

--- a/tests/test_source_object.py
+++ b/tests/test_source_object.py
@@ -27,7 +27,8 @@ class TestFlourishPage:
         assert {
                 'body': u'<p>Hello “world”.</p>',
                 'category': 'static',
-                'published': datetime(2015, 12, 25, 10, 0, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2015, 12, 25, 10, 0, 0, tzinfo=timezone.utc),
                 'tag': 'basic-page',
                 'title': 'Basic Page',
             } == page._config
@@ -39,7 +40,8 @@ class TestFlourishPage:
                 'body': '<h1>Part One</h1>\n\n<p>I come from Markdown.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 4, 11, 0, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 6, 4, 11, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['series', 'one'],
                 'title': 'Part One',
@@ -52,7 +54,8 @@ class TestFlourishPage:
                 'body': u'<p>Body read from Markdown attachment‽</p>\n',
                 'category': 'thing',
                 'line': 'two-things',
-                'published': datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
                 'summary_markdown': 'Thing Two summary.\n',
                 'summary': '<p>Thing Two summary.</p>\n',
                 'tag': ['basically', 'second', 'two'],
@@ -69,7 +72,8 @@ class TestFlourishPage:
                         '<p>The embedded Markdown gets overridden.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 6, 10, 0, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 6, 6, 10, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['three', 'series'],
                 'title': 'Part Three',
@@ -92,7 +96,8 @@ class TestFlourishPage:
                         '<p>I come from a Markdown file.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 4, 12, 0, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 6, 4, 12, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['series', 'two'],
                 'title': 'Part Two',
@@ -115,7 +120,8 @@ class TestFlourishPage:
                         '<p>I was generated from Markdown alone, '
                         'no TOML.</p>\n',
                 'category': 'post',
-                'published': datetime(2016, 2, 29, 10, 30, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 2, 29, 10, 30, 0, tzinfo=timezone.utc),
                 'title': 'Plain Markdown Page',
             } == page._config
 
@@ -126,9 +132,11 @@ class TestFlourishPage:
                         '<p>This is raw HTML.</p>\n',
                 'category': 'thing',
                 'line': 'two-things',
-                'published': datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
+                'published': datetime(
+                    2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
                 'tag': ['basically', 'one', 'first'],
                 'title': u'Thing—the First',
                 'type': 'post',
-                'updated': datetime(2016, 6, 4, 14, 0, 0, tzinfo=timezone.utc),
+                'updated': datetime(
+                    2016, 6, 4, 14, 0, 0, tzinfo=timezone.utc),
             } == page._config

--- a/tests/test_source_object.py
+++ b/tests/test_source_object.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -27,7 +27,7 @@ class TestFlourishPage:
         assert {
                 'body': u'<p>Hello “world”.</p>',
                 'category': 'static',
-                'published': datetime(2015, 12, 25, 10, 0, 0),
+                'published': datetime(2015, 12, 25, 10, 0, 0, tzinfo=timezone.utc),
                 'tag': 'basic-page',
                 'title': 'Basic Page',
             } == page._config
@@ -39,7 +39,7 @@ class TestFlourishPage:
                 'body': '<h1>Part One</h1>\n\n<p>I come from Markdown.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 4, 11, 0, 0),
+                'published': datetime(2016, 6, 4, 11, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['series', 'one'],
                 'title': 'Part One',
@@ -52,7 +52,7 @@ class TestFlourishPage:
                 'body': u'<p>Body read from Markdown attachment‽</p>\n',
                 'category': 'thing',
                 'line': 'two-things',
-                'published': datetime(2016, 6, 4, 12, 30, 0),
+                'published': datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
                 'summary_markdown': 'Thing Two summary.\n',
                 'summary': '<p>Thing Two summary.</p>\n',
                 'tag': ['basically', 'second', 'two'],
@@ -69,7 +69,7 @@ class TestFlourishPage:
                         '<p>The embedded Markdown gets overridden.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 6, 10, 0, 0),
+                'published': datetime(2016, 6, 6, 10, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['three', 'series'],
                 'title': 'Part Three',
@@ -92,7 +92,7 @@ class TestFlourishPage:
                         '<p>I come from a Markdown file.</p>\n',
                 'category': 'article',
                 'index_fkey': 'series/index',
-                'published': datetime(2016, 6, 4, 12, 0, 0),
+                'published': datetime(2016, 6, 4, 12, 0, 0, tzinfo=timezone.utc),
                 'series': 'series-in-three-parts',
                 'tag': ['series', 'two'],
                 'title': 'Part Two',
@@ -115,7 +115,7 @@ class TestFlourishPage:
                         '<p>I was generated from Markdown alone, '
                         'no TOML.</p>\n',
                 'category': 'post',
-                'published': datetime(2016, 2, 29, 10, 30, 0),
+                'published': datetime(2016, 2, 29, 10, 30, 0, tzinfo=timezone.utc),
                 'title': 'Plain Markdown Page',
             } == page._config
 
@@ -126,9 +126,9 @@ class TestFlourishPage:
                         '<p>This is raw HTML.</p>\n',
                 'category': 'thing',
                 'line': 'two-things',
-                'published': datetime(2016, 6, 4, 12, 30, 0),
+                'published': datetime(2016, 6, 4, 12, 30, 0, tzinfo=timezone.utc),
                 'tag': ['basically', 'one', 'first'],
                 'title': u'Thing—the First',
                 'type': 'post',
-                'updated': datetime(2016, 6, 4, 14, 0, 0),
+                'updated': datetime(2016, 6, 4, 14, 0, 0, tzinfo=timezone.utc),
             } == page._config


### PR DESCRIPTION
The atom feeds were generated using a python module called pyatom.

It disappeared. And the namespace filled with a completely different package. Top. Men.

This fixes it. And adds running the tests in GitHub Actions.