### PR TITLE
Fix generate filtering

### DIFF
--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -201,7 +201,7 @@ class Flourish(object):
 
     def generate_url(self, name, report=False):
         url = self._urls[name]
-        url.generator(self, url, self.global_context, report=report)
+        url.generator(self.clone(), url, self.global_context, report=report)
 
     def set_global_context(self, global_context):
         self.global_context = global_context

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -28,6 +28,7 @@ class Flourish(object):
     ARGS = [
         'source_dir',
         'templates_dir',
+        'output_dir',
         'jinja',
     ]
     DATA = [

--- a/tests/source/generate.py
+++ b/tests/source/generate.py
@@ -45,6 +45,14 @@ SOURCE_URL = (
 
 URLS = (
     (
+        # something with a token comes first, as this ensures
+        # that later URLs still generate everything correctly
+        # (ie the flourish object does not have this filter applied)
+        '/tags/#tag/',
+        'tags-tag-page',
+        OnePageIndex.as_generator(),
+    ),
+    (
         '/',
         'homepage',
         NewestFirstIndex.as_generator(),
@@ -58,11 +66,6 @@ URLS = (
         '/404',
         'not-found-page',
         NotFound.as_generator(),
-    ),
-    (
-        '/tags/#tag/',
-        'tags-tag-page',
-        OnePageIndex.as_generator(),
     ),
     (
         '/index.atom',


### PR DESCRIPTION
Hit a bug during the rebuild of my site where some pages just went missing. I had the URLs in my `generate.py` file in a order that meant archives came after the tag pages. This exposed a subtlety of flourish generating pages where it was keeping previous filters in place unhelpfully.

Also found another pernicious bug when trying to debug and fix this.