### PR TITLE
Provide template filters to templates

### DIFF
--- a/documentation/generating-html.markdown
+++ b/documentation/generating-html.markdown
@@ -137,4 +137,4 @@ and uses keys from the source to link to the source page.
 
 Flourish uses Jinja2 to render templates. You can learn a lot more about the
 things you can do in your templates by reading the
-[Jinja2 documentation](http://jinja.pocoo.org).
+[Jinja2 documentation](https://jinja.palletsprojects.com/).

--- a/documentation/template-filters.markdown
+++ b/documentation/template-filters.markdown
@@ -1,0 +1,47 @@
+# Template filters
+
+In addition to the template filters provided by [Jinja][jf],
+you can add your own in your `generate.py`:
+
+```python
+def add_cliche(var):
+    return var + 'I am a cliche that lives next door.'
+
+TEMPLATE_FILTERS = {
+    'cliche': add_cliche,
+}
+```
+
+`TEMPLATE_FILTERS` is a dict that maps the filter name as it will appear
+in the templates to a callable.
+
+[jf]: https://jinja.palletsprojects.com/en/2.11.x/templates/#filters
+
+## Built-in
+
+Flourish comes with two filters that you can use:
+
+```python
+from flourish.filters import ordinal
+
+TEMPLATE_FILTERS = {
+    'ordinal': ordinal,
+}
+```
+
+* `ordinal`
+
+    Given an integer, will return the ordinal suffix of that number
+    in English, ie. `st`, `nd`, `rd`, or `th`.
+
+    ```html
+    {{page.published.day}}{{page.published.day|ordinal}}
+    ```
+
+* `month_name`
+
+    Given an integer between 1 and 12, returns the name of that month.
+
+    ```html
+    <h1>Articles for {{month|month_name}}</h1>
+    ```

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -90,10 +90,17 @@ class Flourish(object):
         generate = SourceFileLoader(
                 'generate', '%s/generate.py' % self.source_dir
             ).load_module()
+
         try:
             self.set_global_context(getattr(generate, 'GLOBAL_CONTEXT'))
         except AttributeError:
             # global context is optional
+            pass
+
+        try:
+            self.add_template_filters(getattr(generate, 'TEMPLATE_FILTERS'))
+        except AttributeError:
+            # filters are optional
             pass
 
         has_urls = False
@@ -232,6 +239,10 @@ class Flourish(object):
 
     def set_global_context(self, global_context):
         self.global_context = global_context
+
+    def add_template_filters(self, filters):
+        for key, value in filters.items():
+            self.jinja.filters[key] = value
 
     def copy_assets(self, report=False):
         for _file in self._assets:

--- a/flourish/filters.py
+++ b/flourish/filters.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+
+def ordinal(value):
+    if value in (11, 12, 13):
+        return 'th'
+    last = value % 10
+    if last == 1:
+        return 'st'
+    if last == 2:
+        return 'nd'
+    if last == 3:
+        return 'rd'
+    return 'th'
+
+def month_name(value):
+    return date(1970, value, 1).strftime('%B')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ pages:
         - Generating the HTML: generating-html.markdown
         - Template variables: template-variables.markdown
         - Template functions: template-functions.markdown
+        - Template filters: template-filters.markdown
         - Site configuration: site-configuration.markdown
         - Adding assets: adding-assets.markdown
     - Advanced usage:

--- a/tests/output/2015/index.html
+++ b/tests/output/2015/index.html
@@ -19,11 +19,24 @@
   <h1>Entries for 2015</h1>
 
   <ul>
+  
     
-      <li>
-        <a href='/basic-page'>Basic Page</a>
+      
+        <li>
+          <h2><a href='/2015/12/'>December</a></h2>
+          <ul>
+    
+
+          <li>
+            25th
+            10:00 <a href='/basic-page'>Basic Page</a>
+          </li>
+  
+    
+        </ul>
       </li>
     
+  
   </ul>
 
   

--- a/tests/output/2016/index.html
+++ b/tests/output/2016/index.html
@@ -19,35 +19,86 @@
   <h1>Entries for 2016</h1>
 
   <ul>
+  
     
-      <li>
-        <a href='/markdown-page'>Plain Markdown Page</a>
+      
+        <li>
+          <h2><a href='/2016/02/'>February</a></h2>
+          <ul>
+    
+
+          <li>
+            29th
+            10:30 <a href='/markdown-page'>Plain Markdown Page</a>
+          </li>
+  
+    
+  
+    
+      
+          </li>
+        </ul>
+      
+        <li>
+          <h2><a href='/2016/06/'>June</a></h2>
+          <ul>
+    
+
+          <li>
+            4th
+            10:00 <a href='/series/'>A Series in Three Parts</a>
+          </li>
+  
+    
+  
+    
+
+          <li>
+            4th
+            11:00 <a href='/series/part-one'>Part One</a>
+          </li>
+  
+    
+  
+    
+
+          <li>
+            4th
+            12:00 <a href='/series/part-two'>Part Two</a>
+          </li>
+  
+    
+  
+    
+
+          <li>
+            4th
+            12:30 <a href='/thing-one'>Thing—the First</a>
+          </li>
+  
+    
+  
+    
+
+          <li>
+            4th
+            12:30 <a href='/thing-two'>Second Thing</a>
+          </li>
+  
+    
+  
+    
+
+          <li>
+            6th
+            10:00 <a href='/series/part-three'>Part Three</a>
+          </li>
+  
+    
+        </ul>
       </li>
     
-      <li>
-        <a href='/series/'>A Series in Three Parts</a>
-      </li>
-    
-      <li>
-        <a href='/series/part-one'>Part One</a>
-      </li>
-    
-      <li>
-        <a href='/series/part-two'>Part Two</a>
-      </li>
-    
-      <li>
-        <a href='/thing-one'>Thing—the First</a>
-      </li>
-    
-      <li>
-        <a href='/thing-two'>Second Thing</a>
-      </li>
-    
-      <li>
-        <a href='/series/part-three'>Part Three</a>
-      </li>
-    
+  
   </ul>
 
   

--- a/tests/source/generate.py
+++ b/tests/source/generate.py
@@ -1,3 +1,4 @@
+from flourish.filters import ordinal
 from flourish.generators import (
     AtomGenerator,
     BaseGenerator,
@@ -52,6 +53,12 @@ def global_context(self):
 
 
 GLOBAL_CONTEXT = global_context
+
+
+TEMPLATE_FILTERS = {
+    'ordinal': ordinal,
+}
+
 
 SOURCE_URL = (
     '/#slug',

--- a/tests/templates/year.html
+++ b/tests/templates/year.html
@@ -4,11 +4,27 @@
   <h1>Entries for {{pages[0].published.year}}</h1>
 
   <ul>
-    {% for page in pages %}
-      <li>
-        <a href='{{page.url}}'>{{page.title}}</a>
+  {% for page in pages %}
+    {% if loop.changed(page.published.month) %}
+      {% if not loop.first %}
+          </li>
+        </ul>
+      {% endif %}
+        <li>
+          <h2><a href='{{ url("month-index", year=page.published.strftime("%Y"), month=page.published.strftime("%m")) }}'>{{page.published.strftime('%B')}}</a></h2>
+          <ul>
+    {% endif %}
+
+          <li>
+            {{page.published.day}}{{page.published.day|ordinal}}
+            {{page.published.strftime('%H:%M')}} <a href='{{page.url}}'>{{page.title}}</a>
+          </li>
+  
+    {% if loop.last %}
+        </ul>
       </li>
-    {% endfor %}
+    {% endif %}
+  {% endfor %}
   </ul>
 
   {% if pagination %}


### PR DESCRIPTION
It is useful to be able to declare your own template filters,
so add a declaration to the `generate.py` to enable them.

Provides two built-in filters that I have needed for my site.