### PR TITLE
Fix slicing

### DIFF
--- a/flourish/generators/mixins.py
+++ b/flourish/generators/mixins.py
@@ -85,7 +85,10 @@ class PathMixin:
         if len(args) == 0:
             valid_filters.append({})
         else:
-            filters = self.flourish.get_valid_filters_for_tokens(args)
+            filters = self.flourish.get_valid_filters_for_tokens(
+                args,
+                self.get_filtered_sources(),
+            )
             for _filter in filters:
                 valid_filters.append(_filter)
         return valid_filters

--- a/flourish/sourcelist.py
+++ b/flourish/sourcelist.py
@@ -96,8 +96,6 @@ class SourceList:
                         add = False
             if add:
                 sources.append(source)
-        if self.slice is not None:
-            sources = sources.__getitem__(self.slice)
         return sources
 
     @property
@@ -148,6 +146,8 @@ class SourceList:
                     'not all sources have that attribute' % order
                 )
 
+        if self.slice is not None:
+            sources = sources.__getitem__(self.slice)
         return iter(sources)
 
     def __len__(self):
@@ -158,11 +158,15 @@ class SourceList:
 
     def __getitem__(self, item):
         if isinstance(item, slice):
-            if (item.start < 0) or (item.stop < 0):
-                raise ValueError('Cannot use negative indexes with Flourish')
-            return self.clone(slice=item)
+            start = item.start
+            stop = item.stop
+            if start and start < 0:
+                start = self.count() + start
+            if stop and stop < 0:
+                stop = self.count() + stop
+            return self.clone(slice=slice(start, stop))
         if item < 0:
-            raise ValueError('Cannot use negative indexes with Flourish')
+            item = self.count() + item
         iterator = iter(self)
         try:
             for i in range(0, item+1):


### PR DESCRIPTION
Slicing against ordered sources was giving the slice on the unordered
sources. While debugging this, I realised negative slices were actually
easily done (not entirely sure why I avoided them at the start).