### PR TITLE
Allow Atom feeds to be customised

### DIFF
--- a/documentation/api-flourish-generators-atom.markdown
+++ b/documentation/api-flourish-generators-atom.markdown
@@ -46,9 +46,22 @@ not be included in the Atom feed.
 
 Bypasses `get_context_data`, `get_template`, `get_template_name` and 
 `render_template`, instead constructing the Atom feed programmatically
-using the `AtomFeed` class provided by [pyatom].
+using the `AtomFeed` class provided by [pyatom], calling `get_entry_content`,
+`get_entry_title`, and `get_entry_id`.
 
 [pyatom]: https://pypi.python.org/pypi/pyatom
+
+### get_entry_content(object)
+
+Return the Atom entry's content. By default just the source object's body.
+
+### get_entry_title(object)
+
+Return the Atom entry's title. By default the source object's title.
+
+### get_entry_id(object)
+
+Return the Atom entry's ID. By default the source object's URL.
 
 ### get_context_data()
 

--- a/documentation/release-notes.markdown
+++ b/documentation/release-notes.markdown
@@ -2,6 +2,26 @@
 
 # Release notes for Flourish
 
+## NEW_VERSION - UNRELEASED
+
+High level description, if applicable.
+
+#### New
+
+#### Other changes
+
+  * Update the [Atom generator][atom] to allow some values to be
+    overridden from the default. Mostly to allow the body of the Atom
+    entry to include more content than just the source's body.
+
+#### Bug fixes
+
+#### Dependency updates
+
+
+[atom]: https://flourish.readthedocs.io/en/latest/api-flourish-generators-atom/
+
+
 ## 0.8 - 2 August 2020
 
   * Always apply the MIME type of a file when uploading to S3.

--- a/flourish/generators/atom.py
+++ b/flourish/generators/atom.py
@@ -49,11 +49,14 @@ class AtomGenerator(SourcesMixin, BaseGenerator):
 
         for _object in self.source_objects:
             entry = feed.add_entry(order='append')
-            entry.title(_object.title)
-            entry.id(_object.absolute_url)
+            entry.title(self.get_entry_title(_object))
+            entry.id(self.get_entry_id(_object))
             entry.link(href=_object.absolute_url, rel='alternate')
             entry.published(_object.published)
-            entry.content(content=_object.body, type='html')
+            entry.content(
+                content=self.get_entry_content(_object),
+                type='html'
+            )
 
             if 'author' in _object:
                 entry.author({'name': _object.author})
@@ -70,6 +73,15 @@ class AtomGenerator(SourcesMixin, BaseGenerator):
         feed.updated(last_updated)
 
         return feed.atom_str(pretty=True)
+
+    def get_entry_content(self, object):
+        return object.body
+
+    def get_entry_title(self, object):
+        return object.title
+
+    def get_entry_id(self, object):
+        return object.absolute_url
 
     # FIXME refactor
     def output_to_file(self):

--- a/tests/output/index.atom
+++ b/tests/output/index.atom
@@ -19,7 +19,7 @@
     <content type="html">&lt;h1&gt;Part Three&lt;/h1&gt;
 
 &lt;p&gt;The embedded Markdown gets overridden.&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/series/part-three" rel="alternate"/>
     <published>2016-06-06T10:00:00+00:00</published>
   </entry>
@@ -32,7 +32,7 @@
     </author>
     <content type="html">&lt;h1&gt;Thing the First&lt;/h1&gt;
 &lt;p&gt;This is raw HTML.&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/thing-one" rel="alternate"/>
     <published>2016-06-04T12:30:00+00:00</published>
   </entry>
@@ -44,7 +44,7 @@
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;p&gt;Body read from Markdown attachment‽&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/thing-two" rel="alternate"/>
     <published>2016-06-04T12:30:00+00:00</published>
   </entry>
@@ -58,7 +58,7 @@
     <content type="html">&lt;h1&gt;Part Two&lt;/h1&gt;
 
 &lt;p&gt;I come from a Markdown file.&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/series/part-two" rel="alternate"/>
     <published>2016-06-04T12:00:00+00:00</published>
   </entry>
@@ -72,7 +72,7 @@
     <content type="html">&lt;h1&gt;Part One&lt;/h1&gt;
 
 &lt;p&gt;I come from Markdown.&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/series/part-one" rel="alternate"/>
     <published>2016-06-04T11:00:00+00:00</published>
   </entry>
@@ -84,7 +84,7 @@
       <name>Wendy Testaburger</name>
     </author>
     <content type="html">&lt;h1&gt;A Series in Three Parts&lt;/h1&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/series/" rel="alternate"/>
     <published>2016-06-04T10:00:00+00:00</published>
   </entry>
@@ -98,7 +98,7 @@
     <content type="html">&lt;h1&gt;¡Markdown!&lt;/h1&gt;
 
 &lt;p&gt;I was generated from Markdown alone, no TOML.&lt;/p&gt;
-</content>
+&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/markdown-page" rel="alternate"/>
     <published>2016-02-29T10:30:00+00:00</published>
   </entry>
@@ -109,7 +109,7 @@
     <author>
       <name>Wendy Testaburger</name>
     </author>
-    <content type="html">&lt;p&gt;Hello “world”.&lt;/p&gt;</content>
+    <content type="html">&lt;p&gt;Hello “world”.&lt;/p&gt;&lt;hr&gt;Originally published on some website</content>
     <link href="http://withaflourish.net/basic-page" rel="alternate"/>
     <published>2015-12-25T10:00:00+00:00</published>
   </entry>

--- a/tests/source/generate.py
+++ b/tests/source/generate.py
@@ -48,6 +48,14 @@ class ArchivePage(SourceGenerator):
         return _context
 
 
+class AttributedAtom(AtomGenerator):
+    def get_entry_content(self, object):
+        return '%s<hr>Originally published on %s' % (
+            object.body,
+            'some website'
+        )
+
+
 def global_context(self):
     return {
         'copyright_year_range': publication_range(self),
@@ -101,7 +109,7 @@ PATHS = (
             'title': 'Not Found',
         },
     ),
-    AtomGenerator(
+    AttributedAtom(
         path = '/index.atom',
         name = 'atom-feed',
     ),


### PR DESCRIPTION
Rather than insisting on the title and body to be exactly the same
as in the source, add methods to get that so they can be overridden.

The ID is most commonly the URL, but that does not have to be the
case, so allow that to be overridden too.