### PR TITLE
Allow excluding sources with future dates

### DIFF
--- a/documentation/release-notes.markdown
+++ b/documentation/release-notes.markdown
@@ -2,6 +2,20 @@
 
 # Release notes for Flourish
 
+## 0.9.2 - UNRELEASED
+
+### New
+
+  * Add `exclude_future` filter to sources that will remove anything with
+    a `published` date in the future
+  * Add `future` setting to the `_site.toml` that, when set to true,
+    removes anything with a `published` date in the future from appearing
+    to any generator (easier than filtering future sources individually)
+  * Add `--exclude-future` and `--include-future` arguments to the
+    `flourish generate` command, that will override the setting in
+    `_site.toml` if necessary.
+
+
 ## 0.9.1 - 18 September 2020
 
 #### Bug fixes

--- a/documentation/site-configuration.markdown
+++ b/documentation/site-configuration.markdown
@@ -1,16 +1,53 @@
 # The site configuration file
 
-If a file called `_site.toml` exists in the source directory, the values 
-in it are made available in all templates. For example, if it contains:
+A file called `_site.toml` must exist in the source directory, and has to
+contain at least the following three keys:
 
-```python
-name = "Wendy's Blog"
-by = 'Wendy Testaburger'
+```toml
+author = ''
+base_url = ''
+title = ''
 ```
 
-then templates can use `site.by` to get "Wendy Testaburger",
-and `site.name` to get "Wendy's Blog". This makes templates more reusable
-across different websites.
+Although these are required, they can be left blank if you are not
+generating Atom feeds.
 
-This file does not have to exist, and there are no required entries in this
-file — unless you are using [Atom feeds](/atom-feeds/).
+Values for author, title, and the base URL of the published site are
+required to generate valid Atom feeds.
+
+
+## Optional keys
+
+There are other keys that Flourish will treat as having special meaning.
+
+  * `future`
+
+    ```toml
+    future = false
+    ```
+
+    If `future` is set to `false`, any source that has a `publication` date
+    that is in the future at the point the site is generated will be ignored.
+
+    By default future publications are included.
+
+  * `bucket`
+
+    ```toml
+    bucket = 'some.bucket'
+    ```
+
+    When using `flourish upload` to push changes to an Amazon S3 bucket,
+    this setting tells Flourish what bucket to use.
+
+
+## Using in templates
+
+The values in the file are made available to all templates under the `site`
+key. For example, a site's footer could include:
+
+```html
+<footer>
+  <p>Copyright {{global.copyright_year_range}} {{site.author}}.</p>
+</footer>
+```

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -34,6 +34,7 @@ class Flourish(object):
         output_dir='output',
         sass_dir='sass',
         fragments_dir=None,
+        future=None,
         skip_scan=False,
     ):
         self.source_dir = source_dir
@@ -41,6 +42,7 @@ class Flourish(object):
         self.fragments_dir = fragments_dir
         self.output_dir = output_dir
         self.sass_dir = sass_dir
+        self.future = future
         self._assets = {}
         self._cache = {}
         self._source_files = []
@@ -97,7 +99,19 @@ class Flourish(object):
 
     @property
     def sources(self):
-        return SourceList(self._source_files)
+        try:
+            future = self.site_config['future'] 
+        except KeyError:
+            future = True
+
+        # object instantiation takes precedence over site config
+        if self.future is not None:
+            future = self.future
+
+        return SourceList(
+            self._source_files,
+            future = future
+        )
 
     def get(self, slug):
         """ Get a single source document by slug. """

--- a/flourish/command_line.py
+++ b/flourish/command_line.py
@@ -173,6 +173,22 @@ def main():
         help='Report each URL as it is generated'
     )
     parser_generate.add_argument(
+        '--include-future',
+        action='store_true',
+        help=(
+            'Include sources with a publication date in the future, '
+            'overriding the "future" setting in _site.toml.'
+        ),
+    )
+    parser_generate.add_argument(
+        '--exclude-future',
+        action='store_true',
+        help=(
+            'Exclude sources with a publication date in the future, '
+            'overriding the "future" setting in _site.toml.'
+        ),
+    )
+    parser_generate.add_argument(
         'path',
         nargs='*',
         help=(
@@ -242,11 +258,17 @@ def main():
 
 
 def generate(args):
+    future = None
+    if args.exclude_future:
+        future = False
+    if args.include_future:
+        future = True
     flourish = Flourish(
         source_dir=args.source,
         templates_dir=args.templates,
         fragments_dir=args.fragments,
         output_dir=args.output,
+        future=future,
     )
     if args.path:
         for path in args.path:

--- a/tests/future/source/_site.toml
+++ b/tests/future/source/_site.toml
@@ -1,0 +1,3 @@
+author = ''
+base_url = ''
+title = ''

--- a/tests/future/source/nineteenth-century.markdown
+++ b/tests/future/source/nineteenth-century.markdown
@@ -1,0 +1,10 @@
+```
+category = 'post'
+published = 1899-01-01T12:00:00Z
+title = '19th Century'
+```
+
+# 19th Century
+
+I am a message from THE FAR PAST and frankly is unlikely to be a real
+blog post.

--- a/tests/future/source/twentieth-century.markdown
+++ b/tests/future/source/twentieth-century.markdown
@@ -1,0 +1,9 @@
+```
+category = 'post'
+published = 1999-01-01T12:00:00Z
+title = '20th Century'
+```
+
+# 20th Century
+
+I am a message from THE PAST.

--- a/tests/future/source/twenty-first-century.markdown
+++ b/tests/future/source/twenty-first-century.markdown
@@ -1,0 +1,9 @@
+```
+category = 'post'
+published = 2020-01-01T12:00:00Z
+title = '21st Century'
+```
+
+# 21st Century
+
+I am a message from THE PRESENT (approximately).

--- a/tests/future/source/twenty-second-century.markdown
+++ b/tests/future/source/twenty-second-century.markdown
@@ -1,0 +1,9 @@
+```
+category = 'post'
+published = 2150-01-01T12:00:00Z
+title = '22nd Century'
+```
+
+# 22nd Century
+
+I am a message from THE FUTURE.

--- a/tests/source/_site.toml
+++ b/tests/source/_site.toml
@@ -1,3 +1,4 @@
 author = 'Wendy Testaburger'
 base_url = 'http://withaflourish.net'
 title = 'Flourish Blog'
+future = false

--- a/tests/source/the-future.markdown
+++ b/tests/source/the-future.markdown
@@ -1,0 +1,9 @@
+```
+category = 'post'
+published = 2099-12-31T23:59:59Z
+title = 'The Future!'
+```
+
+# The Future
+
+I am a message from … THE FUTURE.

--- a/tests/test_flourish_object.py
+++ b/tests/test_flourish_object.py
@@ -1004,3 +1004,44 @@ class TestFlourish:
 
         # ensure still unfiltered
         assert all_dates == self.flourish.publication_dates
+
+class TestFlourishFuture:
+    @classmethod
+    def setup_class(cls):
+        with pytest.warns(None) as warnings:
+            cls.flourish = Flourish(
+                'tests/future/source'
+            )
+            assert len(warnings) == 0
+            assert cls.flourish.sources.count() == 4
+
+    def test_get_all_sources(self):
+        sources = self.flourish.sources.all()
+        assert type(sources) == SourceList
+        assert len(sources) == 4
+        # os.walk order, root dir before subdirs, alphabetical order
+        assert [
+                'nineteenth-century',
+                'twentieth-century',
+                'twenty-first-century',
+                'twenty-second-century',
+            ] == [source.slug for source in sources]
+
+        published = sources.order_by('-published')
+        assert [
+                'twenty-second-century',
+                'twenty-first-century',
+                'twentieth-century',
+                'nineteenth-century',
+            ] == [source.slug for source in published]
+
+    def test_exclude_future(self):
+        sources = self.flourish.sources.exclude_future()
+        assert type(sources) == SourceList
+        assert len(sources) == 3
+        # os.walk order, root dir before subdirs, alphabetical order
+        assert [
+                'nineteenth-century',
+                'twentieth-century',
+                'twenty-first-century',
+            ] == [source.slug for source in sources]

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -52,7 +52,8 @@ class TestRecipe:
             'global': {'copyright_year_range': '2015–2016'},
             'site': {'author': 'Wendy Testaburger',
                      'base_url': 'http://withaflourish.net',
-                     'title': 'Flourish Blog'},
+                     'title': 'Flourish Blog',
+                     'future': False},
             'tokens': {},
         }
         assert recipe['context'].items() >= context_contains.items()
@@ -129,7 +130,8 @@ class TestRecipe:
             'global': {'copyright_year_range': '2015–2016'},
             'site': {'author': 'Wendy Testaburger',
                      'base_url': 'http://withaflourish.net',
-                     'title': 'Flourish Blog'},
+                     'title': 'Flourish Blog',
+                     'future': False},
             'tokens': {},
         }
         assert recipe['context'].items() >= context_contains.items()


### PR DESCRIPTION
Any source that has a `published` date set, and that date is in the
future (as the site is generated) can be ignored when generating a
site.

Setting `future = false` in the `_site.toml`, or passing the
`--exclude-future` option to `flourish generate` will ignore any such
future-dated source.

If `future = false` is set in the `_site.toml`, but future-dated
sources are wanted (eg when testing or previewing), use the
`--include-future` option to `flourish generate`. Both command-line
arguments override any setting in the site configuration.

The default is to include future sources.