### PR TITLE
Fix index sources not being generated in preview

### DIFF
--- a/flourish/generators/mixins.py
+++ b/flourish/generators/mixins.py
@@ -65,7 +65,9 @@ class PathMixin:
                 return []
             check_path = check_path[(pos + len(segments[0])):]
             stripped = re.split(self.STRIP_PATH, check_path)
-            if len(stripped) > 1:
+            if segments[1] == '#slug' and check_path.endswith('/'):
+                path = path + 'index'
+            elif len(stripped) > 1:
                 check_path = stripped[1]
             segments.pop(0)
             segments.pop(0)


### PR DESCRIPTION
If an index page was a source (eg 'something/index.toml') the live
preview server would not generate it, as the generate path checker
did not see it as a match.