### PR TITLE
Disable live preview cache of sectile templates

### DIFF
--- a/documentation/release-notes.markdown
+++ b/documentation/release-notes.markdown
@@ -16,6 +16,9 @@ High level description, if applicable.
     example `flourish generate /2021/?` was generating `/2021/index.html` but
     not `/2021/04/21/index.html`, or any source with a slug starting
     `/2021/...`.
+  * Stop live preview caching sectile-generated templates, which invalidated
+    the point of being able to live preview changes as they are made.
+
 
 #### Dependency updates
 

--- a/flourish/__init__.py
+++ b/flourish/__init__.py
@@ -37,6 +37,7 @@ class Flourish(object):
         fragments_dir=None,
         future=None,
         skip_scan=False,
+        reloading=False,
     ):
         self.source_dir = source_dir
         self.templates_dir = templates_dir
@@ -44,6 +45,7 @@ class Flourish(object):
         self.output_dir = output_dir
         self.sass_dir = sass_dir
         self.future = future
+        self.reloading = reloading
         self._assets = {}
         self._cache = {}
         self._source_files = []
@@ -52,10 +54,14 @@ class Flourish(object):
 
         # using sectile fragments overrides standard filesystem templates
         if self.fragments_dir:
+            cache_size = 400
+            if self.reloading:
+                cache_size = 0
             self.using_sectile = True
             self.jinja = Environment(
                 loader=SectileLoader(self.fragments_dir),
                 keep_trailing_newline=True,
+                cache_size=cache_size,
             )
         else:
             self.using_sectile = False
@@ -188,6 +194,8 @@ class Flourish(object):
             self._paths[path].generate(report)
 
     def generate_path(self, path, report=False):
+        if self.reloading:
+            self._rescan_sources()
         handlers = self.get_handler_for_path(path)
         for key, args in handlers:
             path = self._paths[key]

--- a/flourish/command_line.py
+++ b/flourish/command_line.py
@@ -297,12 +297,16 @@ def generate(args):
 
 def preview_server(args):
     output_dir = os.path.abspath(args.output)
+    reloading = False
+    if args.generate:
+        reloading = True
     try:
         flourish = Flourish(
             source_dir=args.source,
             templates_dir=args.templates,
             fragments_dir=args.fragments,
             output_dir=args.output,
+            reloading=reloading,
         )
     except Flourish.MissingKey as e:
         sys.exit('Error: %s' % str(e))
@@ -331,7 +335,6 @@ def preview_server(args):
 
             # regenerate if requested
             if args.generate:
-                flourish._rescan_sources()
                 flourish.generate_path(generate, report=True)
 
             return send_from_directory(output_dir, path)


### PR DESCRIPTION
Sectile templates being cached during a live preview session stopped
easy development of sectile templates, necessitating restarting the
flourish preview server to reflect changes. Not really the point of
the live preview server.