### PR TITLE
Serve static assets during live preview

### DIFF
--- a/documentation/release-notes.markdown
+++ b/documentation/release-notes.markdown
@@ -8,6 +8,9 @@ High level description, if applicable.
 
 #### New
 
+  * Serve asset files (eg CSS, images, etc) from the source directory
+    during live preview.
+
 #### Other changes
 
 #### Bug fixes

--- a/flourish/command_line.py
+++ b/flourish/command_line.py
@@ -297,6 +297,7 @@ def generate(args):
 
 def preview_server(args):
     output_dir = os.path.abspath(args.output)
+    source_dir = os.path.abspath(args.source)
     reloading = False
     if args.generate:
         reloading = True
@@ -337,7 +338,10 @@ def preview_server(args):
             if args.generate:
                 flourish.generate_path(generate, report=True)
 
-            return send_from_directory(output_dir, path)
+            if os.path.exists(os.path.join(output_dir, path)):
+                return send_from_directory(output_dir, path)
+            else:
+                return send_from_directory(source_dir, path)
 
     @app.after_request
     def add_header(response):


### PR DESCRIPTION
Any static asset files (eg images, CSS, etc) that are in the source
directory should be served during a live preview of the generated
site, so you can see your styles working etc.