### PR TITLE
Allow a generator to not generate without error

### DIFF
--- a/documentation/api-flourish-generators.markdown
+++ b/documentation/api-flourish-generators.markdown
@@ -47,3 +47,15 @@ values available for use in templates.
 ### PageIndexContextMixin
 
 Adds the list of source objects to the template context as `pages`.
+
+
+## Stopping generation
+
+Sometimes you may want to not generate a page (for example, due to a lack of
+content). To do this, raise `DoNotGenerate` and the generator will skip that
+page without it counting as an error.
+
+    def get_objects(self, tokens):
+        sources = self.get_filtered_sources().filter(**tokens)
+        if sources.count() == 0:
+            raise self.DoNotGenerate

--- a/documentation/release-notes.markdown
+++ b/documentation/release-notes.markdown
@@ -10,6 +10,8 @@ High level description, if applicable.
 
   * Serve asset files (eg CSS, images, etc) from the source directory
     during live preview.
+  * Raising `self.DoNotGenerate` in a generator will stop the current
+    page from being generated, without causing any errors.
 
 #### Other changes
 

--- a/flourish/generators/mixins.py
+++ b/flourish/generators/mixins.py
@@ -150,13 +150,19 @@ class SourcesMixin:
 
 
 class GeneratorMixin:
+    class DoNotGenerate(Exception):
+        pass
+
     def generate(self, report=False, tokens=None):
         self.report = report
         if not tokens:
             tokens = self.get_path_tokens()
         for tokenset in tokens:
             self.tokens = tokenset
-            self.generate_path(tokenset)
+            try:
+                self.generate_path(tokenset)
+            except self.DoNotGenerate:
+                pass
 
     def get_path_tokens(self):
         return self.flourish.all_valid_filters_for_path(self.name)

--- a/tests/source/generate.py
+++ b/tests/source/generate.py
@@ -39,6 +39,13 @@ class NotFound(StaticGenerator):
     template_name = '404.html'
 
 
+class NotGenerated(StaticGenerator):
+    template_name = '404.html'
+
+    def get_context_data(self):
+        raise self.DoNotGenerate
+
+
 class ArchivePage(SourceGenerator):
     template_name = 'archive.html'
 
@@ -112,6 +119,13 @@ PATHS = (
         name = 'not-found-page',
         context = {
             'title': 'Not Found',
+        },
+    ),
+    NotGenerated(
+        path = '/404b',
+        name = 'not-generated-page',
+        context = {
+            'title': 'Not Generated',
         },
     ),
     AttributedAtom(


### PR DESCRIPTION
Sometimes a generator may not wish to output a page at runtime.
For example, when generating an index page and it only contains
content scheduled for publication at a future date, that page
should not be created.